### PR TITLE
[#52] - QA- Create collaboration call flow

### DIFF
--- a/backend/src/api/community/content-types/community/schema.json
+++ b/backend/src/api/community/content-types/community/schema.json
@@ -72,6 +72,11 @@
       "type": "relation",
       "relation": "manyToMany",
       "target": "plugin::users-permissions.user"
+    },
+    "members": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "plugin::users-permissions.user"
     }
   }
 }

--- a/backend/src/api/community/controllers/community.js
+++ b/backend/src/api/community/controllers/community.js
@@ -3,38 +3,121 @@
 const { createCoreController } = require("@strapi/strapi").factories;
 
 /**
- * Augment a community entity with a live `posts` count derived from
- * collaboration-call records that reference this community by name.
- * `subscribers` is left as its stored value (defaults to 0) until a
- * subscribe/join flow exists to populate it.
+ * Augment a community entity with live counts:
+ * - `posts`       → collaboration-call records referencing this community
+ * - `subscribers` → number of users in the `members` relation
  */
-async function augmentWithCounts(strapi, item) {
+async function augmentWithCounts(strapi, item, userId) {
   if (!item || !item.name) return item;
+
   const postsCount = await strapi.db
     .query("api::collaboration-call.collaboration-call")
     .count({ where: { communityName: item.name } });
-  return { ...item, posts: postsCount };
+
+  const full = await strapi.db
+    .query("api::community.community")
+    .findOne({
+      where: { documentId: item.documentId },
+      populate: { members: { select: ["id"] } },
+    });
+  const members = full?.members || [];
+
+  const augmented = { ...item, posts: postsCount, subscribers: members.length };
+  if (userId) {
+    augmented.isMember = members.some((m) => m.id === userId);
+  }
+  return augmented;
 }
 
 module.exports = createCoreController(
   "api::community.community",
   ({ strapi }) => ({
     async find(ctx) {
+      const userId = ctx.state?.user?.id;
       const response = await super.find(ctx);
       if (Array.isArray(response?.data)) {
         response.data = await Promise.all(
-          response.data.map((item) => augmentWithCounts(strapi, item)),
+          response.data.map((item) => augmentWithCounts(strapi, item, userId)),
         );
       }
       return response;
     },
 
     async findOne(ctx) {
+      const userId = ctx.state?.user?.id;
       const response = await super.findOne(ctx);
       if (response?.data) {
-        response.data = await augmentWithCounts(strapi, response.data);
+        response.data = await augmentWithCounts(strapi, response.data, userId);
       }
       return response;
+    },
+
+    /**
+     * POST /api/communities/:id/join
+     */
+    async join(ctx) {
+      const user = ctx.state.user;
+      if (!user) return ctx.unauthorized();
+
+      const { id } = ctx.params;
+      const community = await strapi.db
+        .query("api::community.community")
+        .findOne({
+          where: { documentId: id },
+          populate: { members: { select: ["id"] } },
+        });
+
+      if (!community) return ctx.notFound("Community not found");
+
+      const alreadyMember = community.members.some((m) => m.id === user.id);
+      if (alreadyMember) {
+        return {
+          data: { isMember: true, subscribers: community.members.length },
+        };
+      }
+
+      await strapi.db.query("api::community.community").update({
+        where: { id: community.id },
+        data: { members: { connect: [{ id: user.id }] } },
+      });
+
+      return {
+        data: { isMember: true, subscribers: community.members.length + 1 },
+      };
+    },
+
+    /**
+     * POST /api/communities/:id/leave
+     */
+    async leave(ctx) {
+      const user = ctx.state.user;
+      if (!user) return ctx.unauthorized();
+
+      const { id } = ctx.params;
+      const community = await strapi.db
+        .query("api::community.community")
+        .findOne({
+          where: { documentId: id },
+          populate: { members: { select: ["id"] } },
+        });
+
+      if (!community) return ctx.notFound("Community not found");
+
+      const isMember = community.members.some((m) => m.id === user.id);
+      if (!isMember) {
+        return {
+          data: { isMember: false, subscribers: community.members.length },
+        };
+      }
+
+      await strapi.db.query("api::community.community").update({
+        where: { id: community.id },
+        data: { members: { disconnect: [{ id: user.id }] } },
+      });
+
+      return {
+        data: { isMember: false, subscribers: community.members.length - 1 },
+      };
     },
   }),
 );

--- a/backend/src/api/community/routes/custom.js
+++ b/backend/src/api/community/routes/custom.js
@@ -1,0 +1,16 @@
+"use strict";
+
+module.exports = {
+  routes: [
+    {
+      method: "POST",
+      path: "/communities/:id/join",
+      handler: "community.join",
+    },
+    {
+      method: "POST",
+      path: "/communities/:id/leave",
+      handler: "community.leave",
+    },
+  ],
+};

--- a/backend/src/utils/seeder.js
+++ b/backend/src/utils/seeder.js
@@ -363,6 +363,8 @@ const seed = async (strapi) => {
     "api::resource.resource.findOne",
     "api::resource.resource.create",
     "plugin::upload.content-api.upload",
+    "api::community.community.join",
+    "api::community.community.leave",
   ];
 
   for (const action of collaborationActions) {

--- a/frontend/components/collaboration/StepInviteUsers.jsx
+++ b/frontend/components/collaboration/StepInviteUsers.jsx
@@ -7,7 +7,7 @@ import { Plus, Mail, Info, Loader2 } from "lucide-react";
 import { createCollaborationCall } from "@/lib/strapi";
 
 export default function StepInviteUsers() {
-  const { formData, addInviteEmail, removeInviteEmail, nextStep, prevStep } =
+  const { formData, addInviteEmail, removeInviteEmail, updateFormData, nextStep, prevStep } =
     useCollaborationStore();
 
   const [emailInputs, setEmailInputs] = useState(() => {
@@ -64,6 +64,7 @@ export default function StepInviteUsers() {
       });
 
       if (result && !result.error) {
+        updateFormData({ createdCallDocumentId: result.data?.documentId || result.documentId });
         nextStep();
       } else {
         setError(result?.error || "Failed to create collaboration call");
@@ -92,6 +93,7 @@ export default function StepInviteUsers() {
       });
 
       if (result && !result.error) {
+        updateFormData({ createdCallDocumentId: result.data?.documentId || result.documentId });
         nextStep();
       } else {
         setError(result?.error || "Failed to create collaboration call");

--- a/frontend/components/collaboration/StepSuccess.jsx
+++ b/frontend/components/collaboration/StepSuccess.jsx
@@ -12,8 +12,9 @@ export default function StepSuccess() {
   };
 
   const handleAccessPage = () => {
+    const callId = formData.createdCallDocumentId;
     close();
-    router.push("/community");
+    router.push(callId ? `/community/calls/${callId}` : "/community");
   };
 
   return (

--- a/frontend/lib/collaboration-store.js
+++ b/frontend/lib/collaboration-store.js
@@ -18,7 +18,15 @@ export const useCollaborationStore = create(
         mentors: [],
       },
 
-      open: () => set({ isOpen: true, step: 1 }),
+      open: (communityName) =>
+        set((state) => ({
+          isOpen: true,
+          step: 1,
+          formData: {
+            ...state.formData,
+            communityName: communityName || "",
+          },
+        })),
       close: () =>
         set({
           isOpen: false,

--- a/frontend/lib/strapi.js
+++ b/frontend/lib/strapi.js
@@ -232,6 +232,32 @@ export async function fetchCommunityByName(name) {
 }
 
 /**
+ * Join a community (authenticated)
+ */
+export async function joinCommunity(documentId) {
+  try {
+    const response = await apiClient.post(`/communities/${documentId}/join`);
+    return response.data;
+  } catch (error) {
+    console.error("Error joining community:", error);
+    return error;
+  }
+}
+
+/**
+ * Leave a community (authenticated)
+ */
+export async function leaveCommunity(documentId) {
+  try {
+    const response = await apiClient.post(`/communities/${documentId}/leave`);
+    return response.data;
+  } catch (error) {
+    console.error("Error leaving community:", error);
+    return error;
+  }
+}
+
+/**
  * Fetch collaboration calls for a given community (by community name).
  * Returns them newest-first.
  */

--- a/frontend/pages/community/[slug].js
+++ b/frontend/pages/community/[slug].js
@@ -18,7 +18,7 @@ import ResourcesList from "@/components/community/ResourcesList";
 import CreateCollaborationDialog from "@/components/collaboration/CreateCollaborationDialog";
 import { useCollaborationStore } from "@/lib/collaboration-store";
 import { useAuthStore } from "@/lib/auth-store";
-import { fetchCommunity, fetchCollaborationCalls } from "@/lib/strapi";
+import { fetchCommunity, fetchCollaborationCalls, joinCommunity, leaveCommunity } from "@/lib/strapi";
 import { COMMUNITY_TABS } from "@/lib/community-mock-data";
 
 function mapCallFromApi(c) {
@@ -44,18 +44,37 @@ export default function CommunityDetailPage() {
   const router = useRouter();
   const openCollaborationDialog = useCollaborationStore((s) => s.open);
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const user = useAuthStore((s) => s.user);
+
+  const [community, setCommunity] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [calls, setCalls] = useState([]);
+  const [isMember, setIsMember] = useState(false);
+  const { slug } = router.query;
 
   const openCollaboration = () => {
     if (!isAuthenticated) {
       router.push("/login");
       return;
     }
-    openCollaborationDialog();
+    openCollaborationDialog(community?.name);
   };
-  const [community, setCommunity] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [calls, setCalls] = useState([]);
-  const { slug } = router.query;
+
+  const handleJoin = async () => {
+    if (!isAuthenticated) {
+      router.push("/login");
+      return;
+    }
+    const action = isMember ? leaveCommunity : joinCommunity;
+    const res = await action(community.documentId);
+    if (res?.data) {
+      setIsMember(res.data.isMember);
+      setCommunity((prev) => ({
+        ...prev,
+        stats: { ...prev.stats, subscribers: res.data.subscribers },
+      }));
+    }
+  };
 
   useEffect(() => {
     if (!slug) return;
@@ -64,7 +83,7 @@ export default function CommunityDetailPage() {
       if (items.length > 0) {
         const c = items[0];
         // Normalise shape for existing components
-        setCommunity({
+        const normalized = {
           ...c,
           about: c.description,
           stats: { subscribers: c.subscribers || 0, posts: c.posts || 0 },
@@ -77,7 +96,11 @@ export default function CommunityDetailPage() {
             id: m.documentId || m.id,
             name: m.username || m.email,
           })),
-        });
+        };
+        setCommunity(normalized);
+        if (c.isMember !== undefined) {
+          setIsMember(c.isMember);
+        }
       }
       setLoading(false);
     });
@@ -140,6 +163,8 @@ export default function CommunityDetailPage() {
         <CommunityHeader
           community={community}
           onCreatePost={openCollaboration}
+          isJoined={isMember}
+          onJoin={handleJoin}
         />
 
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_18rem]">

--- a/frontend/pages/community/calls/[id].js
+++ b/frontend/pages/community/calls/[id].js
@@ -356,9 +356,6 @@ function ChatHeader({ call, isActive, onBack }) {
             {datePrefix}: {formatShortDate(call.endDate)}
           </span>
         </div>
-        <Button size="sm" variant="outline" className="rounded-full">
-          Request to join
-        </Button>
       </div>
     </div>
   );

--- a/frontend/pages/community/index.js
+++ b/frontend/pages/community/index.js
@@ -5,7 +5,8 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import CommunityLeftNav from "@/components/community/CommunityLeftNav";
-import { fetchCommunities } from "@/lib/strapi";
+import { fetchCommunities, joinCommunity, leaveCommunity } from "@/lib/strapi";
+import { useAuthStore } from "@/lib/auth-store";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
 const ALL_TAG = "All";
@@ -18,6 +19,7 @@ function formatCount(n) {
 
 function CommunityCard({ community, onJoin }) {
   const router = useRouter();
+  const joined = community.isMember;
 
   return (
     <div
@@ -44,15 +46,15 @@ function CommunityCard({ community, onJoin }) {
           </div>
         </div>
         <Button
-          variant="tertiary"
+          variant={joined ? "primary" : "tertiary"}
           size="sm"
-          className="flex-none bg-[#E8ECEF] text-black hover:bg-[#dde1e4]"
+          className={joined ? "flex-none" : "flex-none bg-[#E8ECEF] text-black hover:bg-[#dde1e4]"}
           onClick={(e) => {
             e.stopPropagation();
             onJoin?.(community);
           }}
         >
-          Join
+          {joined ? "Joined" : "Join"}
         </Button>
       </div>
 
@@ -67,6 +69,7 @@ function CommunityCard({ community, onJoin }) {
 
 export default function CommunitiesPage() {
   const router = useRouter();
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const [communities, setCommunities] = useState([]);
   const [loading, setLoading] = useState(true);
   const [activeTag, setActiveTag] = useState(ALL_TAG);
@@ -81,6 +84,24 @@ export default function CommunitiesPage() {
       setLoading(false);
     });
   }, []);
+
+  const handleJoin = async (community) => {
+    if (!isAuthenticated) {
+      router.push("/login");
+      return;
+    }
+    const action = community.isMember ? leaveCommunity : joinCommunity;
+    const res = await action(community.documentId);
+    if (res?.data) {
+      setCommunities((prev) =>
+        prev.map((c) =>
+          c.documentId === community.documentId
+            ? { ...c, isMember: res.data.isMember, subscribers: res.data.subscribers }
+            : c,
+        ),
+      );
+    }
+  };
 
   const updateScrollButtons = () => {
     const el = tagsScrollRef.current;
@@ -211,6 +232,7 @@ export default function CommunitiesPage() {
               <CommunityCard
                 key={community.documentId || community.id}
                 community={community}
+                onJoin={handleJoin}
               />
             ))}
           </div>


### PR DESCRIPTION
This pull request implements community membership management, allowing users to join and leave communities, and updates both backend and frontend to support this. It also improves the collaboration call creation flow by redirecting users to the newly created call page. The most important changes are grouped below.

**Backend: Community Membership Features**

* Added a `members` many-to-many relation to the `community` schema, enabling tracking of user memberships.
* Updated the community controller to:
  * Augment community entities with live `subscribers` counts and an `isMember` flag for the current user.
  * Add new endpoints: `join` and `leave` to allow authenticated users to join or leave a community.
* Registered the new `join` and `leave` endpoints in custom routes.
* Updated the seeder utility to include permissions for the new join/leave actions.

**Frontend: Community Membership UI and Logic**

* Added `joinCommunity` and `leaveCommunity` API methods, and integrated them into the community detail page. Users can now join or leave a community, with UI state reflecting membership and subscriber count in real time. ([frontend/lib/strapi.jsR234-R259](diffhunk://#diff-2d617fb0898a32f07063572f81d9b44ad8729c062a87880da6e5a3293a735706R234-R259), [frontend/pages/community/[slug].jsL21-R21](diffhunk://#diff-43fa6403185d96dc450565f20f02a0e78fb13486b856cce488be5371a276a01eL21-R21), [frontend/pages/community/[slug].jsR47-L58](diffhunk://#diff-43fa6403185d96dc450565f20f02a0e78fb13486b856cce488be5371a276a01eR47-L58), [frontend/pages/community/[slug].jsL67-R86](diffhunk://#diff-43fa6403185d96dc450565f20f02a0e78fb13486b856cce488be5371a276a01eL67-R86), [frontend/pages/community/[slug].jsL80-R103](diffhunk://#diff-43fa6403185d96dc450565f20f02a0e78fb13486b856cce488be5371a276a01eL80-R103), [frontend/pages/community/[slug].jsR166-R167](diffhunk://#diff-43fa6403185d96dc450565f20f02a0e78fb13486b856cce488be5371a276a01eR166-R167))
* Updated the collaboration dialog store and flow so that after creating a collaboration call, users are redirected directly to the new call’s page. [[1]](diffhunk://#diff-95b30edb4fa7143db12c285669a316ddedde0032c1bb14865ebb7a47d50c58beL10-R10) [[2]](diffhunk://#diff-95b30edb4fa7143db12c285669a316ddedde0032c1bb14865ebb7a47d50c58beR67) [[3]](diffhunk://#diff-95b30edb4fa7143db12c285669a316ddedde0032c1bb14865ebb7a47d50c58beR96) [[4]](diffhunk://#diff-b42b3cbb980247070da4ea7ac9dc6d00d9c1d519f17d2d484eccf74517c0c22eR15-R17) [[5]](diffhunk://#diff-b352f4145714b302c6781b98f8328abf37f2a3a4da9fc0e7f365744c298b5e70L21-R29)
* Cleaned up the call page header by removing the unused "Request to join" button. ([frontend/pages/community/calls/[id].jsL359-L361](diffhunk://#diff-2e33ea2b5c462c4185d67dd002266aca1e8ae707b7d3be9fdd9294a1c1e147a8L359-L361))

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214290030483526