### PR TITLE
[#56] Infrastructure - Fix Strapi Admin Blank Page in Production

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -46,6 +46,7 @@ jobs:
           service-name: "backend"
           dockerfile-location: "backend"
           cluster-name: "test"
+          build-args: "BACKEND_URL=https://science-of-africa.akvotest.org/cms"
 
       - name: Docker Push Nginx
         uses: ./composite-actions/.github/actions/docker-push

--- a/docs/low-level-design.md
+++ b/docs/low-level-design.md
@@ -103,7 +103,7 @@ The email verification flow: after registration, the user lands on a verificatio
 | Tool | Purpose |
 |---|---|
 | Docker & Docker Compose | Containerised development and mimic-prod environments |
-| Nginx 1.26 (Alpine) | Reverse proxy — routes `/` → frontend:3000, `/cms/` → backend:1337 with path rewrite |
+| Nginx 1.26 (Alpine) | Reverse proxy — routes `/` → frontend:3000, `/cms/` → backend:1337 |
 | GitHub Actions | CI/CD — build, push to container registry, Kubernetes rollout |
 | Mailpit | Dev-only email testing (SMTP mock on port 1025, web inspector on port 8025) |
 | PgAdmin 4 | Dev-only database inspection (port 5050) |
@@ -452,7 +452,7 @@ Push to main
 - `GH_PAT` — access to `akvo/composite-actions` repo
 
 **Kubernetes deployments:**
-1. **nginx** — reverse proxy, routes `/` and `/cms/`
+1. **nginx** — reverse proxy, routes `/` and `/cms/`. Note: Nginx must NOT strip the `/cms/` prefix when proxying to Strapi, as Strapi (configured with a subpath) handles its own routing.
 2. **frontend** — Next.js production build (Node 20 Alpine, port 3000)
 3. **backend** — Strapi production build (Node 22 Alpine, port 1337)
 
@@ -462,7 +462,7 @@ Push to main
 
 **Critical Configuration Notes:**
 - **Strapi Build-time URL**: Strapi's admin panel is a React application built during the Docker build phase. It **must** know its public base path (e.g., `/cms`) at build time to correctly resolve asset paths (JS/CSS). This is passed via the `BACKEND_URL` build argument in the Dockerfile. Failure to provide this will result in a blank white page in production as assets will attempt to load from the root `/` instead of the subpath.
-- **Path Consistency**: The `BACKEND_URL` should be the base URL of the Strapi application (e.g., `https://domain.com/cms`). Do not include the `/api` suffix in the base `BACKEND_URL`, as Strapi appends this automatically for its REST endpoints.
+- **Path Consistency**: The `BACKEND_URL` should be the base URL of the Strapi application (e.g., `https://domain.com/cms`). Do not include the `/api` suffix in the base `BACKEND_URL`, as Strapi appends this automatically for its REST endpoints. **Important**: When hosting on a subpath like `/cms`, ensure that the proxy (Nginx) does NOT use a rewrite rule to strip the prefix, as Strapi expects the full path for its internal routing.
 
 K8s manifests are managed within Akvo's infrastructure (via the `composite-actions` repo and cluster configuration), not stored in this application repo.
 

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -39,11 +39,8 @@ server {
         proxy_cache_bypass $http_upgrade;
     }
 
-    # Proxy /cms/* to Strapi, stripping the prefix
+    # Proxy /cms/* to Strapi
     location /cms/ {
-        # Strip /cms prefix
-        rewrite ^/cms/?(.*)$ /$1 break;
-
         proxy_pass http://backend;
         proxy_http_version 1.1;
 


### PR DESCRIPTION
## Description
Resolves the blank white page issue in the Strapi Admin panel by aligning Nginx routing and build-time URL injection.

## Changes
- Removed Nginx prefix stripping for the /cms subpath.
- Added BACKEND_URL build argument to the backend deployment workflow.
- Updated LLD documentation with infrastructure requirements.

## Verification
- Verified by checking that asset paths in the browser console now correctly include the /cms prefix.
- Confirmed that Strapi receives full paths required for its internal routing.